### PR TITLE
Use v2/numerai_live_data.csv

### DIFF
--- a/making-your-first-submission-on-numerai.ipynb
+++ b/making-your-first-submission-on-numerai.ipynb
@@ -698,7 +698,10 @@
       },
       "source": [
         "# download the latest tournament dataset (takes around 30s)\n",
-        "tournament_data = pd.read_csv(\"https://numerai-public-datasets.s3-us-west-2.amazonaws.com/latest_numerai_tournament_data.csv.xz\")\n",
+        "napi = numerapi.NumerAPI()\n",
+        "current_round = napi.get_current_round(tournament=8)\n",
+        "napi.download_dataset('v2/numerai_live_data.csv', f"live_{current_round}_v2.csv")\n",
+        "tournament_data = pd.read_csv(f"live_{current_round}_v2.csv")\n",
         "tournament_data.head()"
       ],
       "execution_count": 0,


### PR DESCRIPTION
Use v2/numerai_live_data.csv instead of latest_numerai_tournament_data.csv.xz so that notebook functions on daily rounds.