### PR TITLE
Change sklearn to scikit-learn

### DIFF
--- a/making-your-first-submission-on-numerai.ipynb
+++ b/making-your-first-submission-on-numerai.ipynb
@@ -74,7 +74,7 @@
       },
       "source": [
         "# install dependencies\n",
-        "!pip install pandas sklearn numerapi"
+        "!pip install pandas scikit-learn numerapi"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
Change "!pip install pandas sklearn numerapi" to "!pip install pandas scikit-learn numerapi". sklearn is incorrect, scikit-learn is the proper package name.